### PR TITLE
Sql server connections

### DIFF
--- a/EnvironmentManager4/BuildLog.Designer.cs
+++ b/EnvironmentManager4/BuildLog.Designer.cs
@@ -52,7 +52,7 @@ namespace EnvironmentManager4
             // btnLaunch
             // 
             this.btnLaunch.Enabled = false;
-            this.btnLaunch.Location = new System.Drawing.Point(364, 450);
+            this.btnLaunch.Location = new System.Drawing.Point(87, 435);
             this.btnLaunch.Name = "btnLaunch";
             this.btnLaunch.Size = new System.Drawing.Size(75, 23);
             this.btnLaunch.TabIndex = 13;
@@ -65,7 +65,7 @@ namespace EnvironmentManager4
             this.cbProduct.AutoSize = true;
             this.cbProduct.Checked = true;
             this.cbProduct.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbProduct.Location = new System.Drawing.Point(552, 454);
+            this.cbProduct.Location = new System.Drawing.Point(547, 439);
             this.cbProduct.Name = "cbProduct";
             this.cbProduct.Size = new System.Drawing.Size(90, 17);
             this.cbProduct.TabIndex = 12;
@@ -74,7 +74,7 @@ namespace EnvironmentManager4
             // 
             // btnRefresh
             // 
-            this.btnRefresh.Location = new System.Drawing.Point(2, 450);
+            this.btnRefresh.Location = new System.Drawing.Point(9, 435);
             this.btnRefresh.Name = "btnRefresh";
             this.btnRefresh.Size = new System.Drawing.Size(75, 23);
             this.btnRefresh.TabIndex = 11;
@@ -85,7 +85,7 @@ namespace EnvironmentManager4
             // cbDlls
             // 
             this.cbDlls.AutoSize = true;
-            this.cbDlls.Location = new System.Drawing.Point(648, 454);
+            this.cbDlls.Location = new System.Drawing.Point(643, 439);
             this.cbDlls.Name = "cbDlls";
             this.cbDlls.Size = new System.Drawing.Size(70, 17);
             this.cbDlls.TabIndex = 10;
@@ -94,7 +94,7 @@ namespace EnvironmentManager4
             // 
             // btnCopy
             // 
-            this.btnCopy.Location = new System.Drawing.Point(724, 450);
+            this.btnCopy.Location = new System.Drawing.Point(719, 435);
             this.btnCopy.Name = "btnCopy";
             this.btnCopy.Size = new System.Drawing.Size(75, 23);
             this.btnCopy.TabIndex = 9;
@@ -106,7 +106,7 @@ namespace EnvironmentManager4
             // 
             this.groupBox2.Controls.Add(this.lvDlls);
             this.groupBox2.ForeColor = System.Drawing.Color.Blue;
-            this.groupBox2.Location = new System.Drawing.Point(3, 228);
+            this.groupBox2.Location = new System.Drawing.Point(3, 213);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(796, 219);
             this.groupBox2.TabIndex = 8;
@@ -123,7 +123,7 @@ namespace EnvironmentManager4
             this.lvDlls.HideSelection = false;
             this.lvDlls.Location = new System.Drawing.Point(7, 20);
             this.lvDlls.Name = "lvDlls";
-            this.lvDlls.Size = new System.Drawing.Size(783, 193);
+            this.lvDlls.Size = new System.Drawing.Size(783, 181);
             this.lvDlls.TabIndex = 0;
             this.lvDlls.UseCompatibleStateImageBehavior = false;
             this.lvDlls.View = System.Windows.Forms.View.Details;
@@ -131,7 +131,7 @@ namespace EnvironmentManager4
             // chDllName
             // 
             this.chDllName.Text = "Name";
-            this.chDllName.Width = 515;
+            this.chDllName.Width = 534;
             // 
             // chType
             // 
@@ -144,7 +144,7 @@ namespace EnvironmentManager4
             this.groupBox1.ForeColor = System.Drawing.Color.Blue;
             this.groupBox1.Location = new System.Drawing.Point(3, 3);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(796, 219);
+            this.groupBox1.Size = new System.Drawing.Size(796, 207);
             this.groupBox1.TabIndex = 7;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Builds";
@@ -162,7 +162,7 @@ namespace EnvironmentManager4
             this.lvBuilds.Location = new System.Drawing.Point(7, 20);
             this.lvBuilds.MultiSelect = false;
             this.lvBuilds.Name = "lvBuilds";
-            this.lvBuilds.Size = new System.Drawing.Size(783, 193);
+            this.lvBuilds.Size = new System.Drawing.Size(783, 181);
             this.lvBuilds.TabIndex = 0;
             this.lvBuilds.UseCompatibleStateImageBehavior = false;
             this.lvBuilds.View = System.Windows.Forms.View.Details;
@@ -171,7 +171,7 @@ namespace EnvironmentManager4
             // chPath
             // 
             this.chPath.Text = "Path";
-            this.chPath.Width = 465;
+            this.chPath.Width = 484;
             // 
             // chVersion
             // 
@@ -192,7 +192,7 @@ namespace EnvironmentManager4
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 476);
+            this.ClientSize = new System.Drawing.Size(800, 460);
             this.Controls.Add(this.btnLaunch);
             this.Controls.Add(this.cbProduct);
             this.Controls.Add(this.btnRefresh);

--- a/EnvironmentManager4/BuildLog.cs
+++ b/EnvironmentManager4/BuildLog.cs
@@ -35,11 +35,13 @@ namespace EnvironmentManager4
                 item1.SubItems.Add(build.Product);
                 lvBuilds.Items.Add(item1);
             }
+            Utilities.ResizeListviewColumnWidth(lvBuilds, 9, 0, 467, 484);
         }
 
         private void BuildLog_Load(object sender, EventArgs e)
         {
             LoadBuildLog();
+            return;
         }
 
         private void lvBuilds_SelectedIndexChanged(object sender, EventArgs e)
@@ -62,6 +64,7 @@ namespace EnvironmentManager4
                 item1.SubItems.Add(dll.Type);
                 lvDlls.Items.Add(item1);
             }
+            Utilities.ResizeListviewColumnWidth(lvDlls, 9, 1, 228, 245);
             return;
         }
 

--- a/EnvironmentManager4/BuildModel.cs
+++ b/EnvironmentManager4/BuildModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,6 +23,16 @@ namespace EnvironmentManager4
             this.EntryDate = EntryDate;
             this.Product = Product;
             this.InstallPath = InstallPath;
+        }
+
+        public void LaunchBuild()
+        {
+            Process.Start(String.Format(@"{0}\{1}", this.InstallPath, Utilities.RetrieveExe(this.Product)));
+        }
+
+        public void LaunchInstalledFolder()
+        {
+            Process.Start(this.InstallPath);
         }
     }
 }

--- a/EnvironmentManager4/DatabaseActivityLog.Designer.cs
+++ b/EnvironmentManager4/DatabaseActivityLog.Designer.cs
@@ -66,7 +66,7 @@ namespace EnvironmentManager4
             // chBackup
             // 
             this.chBackup.Text = "Backup";
-            this.chBackup.Width = 465;
+            this.chBackup.Width = 488;
             // 
             // DatabaseActivityLog
             // 

--- a/EnvironmentManager4/DatabaseActivityLog.cs
+++ b/EnvironmentManager4/DatabaseActivityLog.cs
@@ -29,6 +29,7 @@ namespace EnvironmentManager4
                 item1.SubItems.Add(activity.Backup);
                 lvDatabaseActivityLog.Items.Add(item1);
             }
+            Utilities.ResizeListviewColumnWidth(lvDatabaseActivityLog, 15, 2, 471, 488);
         }
 
         private void DatabaseActivityLog_Load(object sender, EventArgs e)

--- a/EnvironmentManager4/DatabaseManagement.cs
+++ b/EnvironmentManager4/DatabaseManagement.cs
@@ -14,11 +14,11 @@ namespace EnvironmentManager4
 {
     public class DatabaseManagement
     {
-        public static void ResetDatabaseVersion(string database = "TWO")
+        public static void ResetDatabaseVersion(string username, string password, string database = "TWO")
         {
             string script = String.Format("USE {0} EXEC dbo.sppResetDatabase", database);
             SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
-            SqlConnection sqlCon = new SqlConnection(String.Format(@"Data Source={0};Initial Catalog=MASTER;User ID=sa;Password=sa;", settingsModel.DbManagement.SQLServer));
+            SqlConnection sqlCon = new SqlConnection(String.Format(@"Data Source={0};Initial Catalog=MASTER;User ID={1};Password={2};", settingsModel.DbManagement.Connection, username, password));
             SqlDataAdapter sqlAdapter = new SqlDataAdapter(script, sqlCon);
             DataTable dataTable = new DataTable();
             try
@@ -58,7 +58,7 @@ namespace EnvironmentManager4
             Form1.EnableDBControls(false);
 
             SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
-            if (settingsModel.DbManagement.Databases.Count <= 0 || String.IsNullOrWhiteSpace(settingsModel.DbManagement.SQLServer))
+            if (settingsModel.DbManagement.Databases.Count <= 0 || String.IsNullOrWhiteSpace(settingsModel.DbManagement.Connection))
             {
                 MessageBox.Show("SQL Server/Databases aren't configured in Settings. Please ensure a SQL Server connection is established and databases are selected in Settings.");
                 return;
@@ -82,7 +82,7 @@ namespace EnvironmentManager4
 
                 try
                 {
-                    SqlConnection sqlCon = new SqlConnection(String.Format(@"Data Source={0};Initial Catalog=MASTER;User ID=sa;Password=sa;", settingsModel.DbManagement.SQLServer));
+                    SqlConnection sqlCon = new SqlConnection(String.Format(@"Data Source={0};Initial Catalog=MASTER;User ID={1};Password={2};", settingsModel.DbManagement.Connection, settingsModel.DbManagement.SQLServerUserName, Utilities.ToInsecureString(Utilities.DecryptString(settingsModel.DbManagement.SQLServerPassword))));
                     SqlDataAdapter restoreScript = new SqlDataAdapter(script, sqlCon);
                     DataTable restoreTable = new DataTable();
                     restoreScript.Fill(restoreTable);
@@ -153,7 +153,7 @@ namespace EnvironmentManager4
                 return;
             }
             SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
-            if (settingsModel.DbManagement.Databases.Count <= 0 || String.IsNullOrWhiteSpace(settingsModel.DbManagement.SQLServer))
+            if (settingsModel.DbManagement.Databases.Count <= 0 || String.IsNullOrWhiteSpace(settingsModel.DbManagement.Connection))
             {
                 MessageBox.Show("SQL Server/Databases aren't configured in Settings. Please ensure a SQL Server connection is established and databases are selected in Settings.");
                 return;
@@ -162,7 +162,7 @@ namespace EnvironmentManager4
             {
                 string script = String.Format(@"BACKUP DATABASE {0} TO DISK='{1}\{2}\{0}.bak' WITH INIT", databaseFile, settingsModel.DbManagement.DatabaseBackupDirectory, databaseName);
 
-                SqlConnection sqlCon = new SqlConnection(String.Format(@"Data Source={0};Initial Catalog=MASTER;User ID=sa;Password=sa;", settingsModel.DbManagement.SQLServer));
+                SqlConnection sqlCon = new SqlConnection(String.Format(@"Data Source={0};Initial Catalog=MASTER;User ID={1};Password={2};", settingsModel.DbManagement.Connection, settingsModel.DbManagement.SQLServerUserName, Utilities.ToInsecureString(Utilities.DecryptString(settingsModel.DbManagement.SQLServerPassword))));
                 SqlDataAdapter newDBScript = new SqlDataAdapter(script, sqlCon);
                 DataTable newDBTable = new DataTable();
                 try

--- a/EnvironmentManager4/Environment Manager.csproj
+++ b/EnvironmentManager4/Environment Manager.csproj
@@ -55,6 +55,7 @@
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Security" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/EnvironmentManager4/Environment Manager.csproj
+++ b/EnvironmentManager4/Environment Manager.csproj
@@ -148,6 +148,7 @@
       <DependentUpon>TextPrompt.cs</DependentUpon>
     </Compile>
     <Compile Include="Utilities.cs" />
+    <Compile Include="Variance.cs" />
     <EmbeddedResource Include="BuildLog.resx">
       <DependentUpon>BuildLog.cs</DependentUpon>
     </EmbeddedResource>

--- a/EnvironmentManager4/Files/Settings.json
+++ b/EnvironmentManager4/Files/Settings.json
@@ -1,9 +1,12 @@
 {
   "DbManagement": {
     "DatabaseBackupDirectory": "",
-    "SQLServer": "",
+    "Connection": "",
+    "ConnectionsList": [],
+    "SQLServerUserName": "",
+    "SQLServerPassword": "",
     "Databases": [],
-    "LockedIn": false
+    "Connected": false
   },
   "BuildManagement": {
     "SalesPadx86Directory": "C:\\Program Files (x86)\\SalesPad.Desktop",

--- a/EnvironmentManager4/Form1.Designer.cs
+++ b/EnvironmentManager4/Form1.Designer.cs
@@ -96,7 +96,7 @@ namespace EnvironmentManager4
             // labelReloadVPNIPAddress
             // 
             this.labelReloadVPNIPAddress.AutoSize = true;
-            this.labelReloadVPNIPAddress.Location = new System.Drawing.Point(145, 566);
+            this.labelReloadVPNIPAddress.Location = new System.Drawing.Point(89, 566);
             this.labelReloadVPNIPAddress.Name = "labelReloadVPNIPAddress";
             this.labelReloadVPNIPAddress.Size = new System.Drawing.Size(45, 13);
             this.labelReloadVPNIPAddress.TabIndex = 18;
@@ -105,7 +105,7 @@ namespace EnvironmentManager4
             // 
             // tbSPVPNIPAddress
             // 
-            this.tbSPVPNIPAddress.Location = new System.Drawing.Point(192, 563);
+            this.tbSPVPNIPAddress.Location = new System.Drawing.Point(136, 563);
             this.tbSPVPNIPAddress.Name = "tbSPVPNIPAddress";
             this.tbSPVPNIPAddress.ReadOnly = true;
             this.tbSPVPNIPAddress.Size = new System.Drawing.Size(123, 20);
@@ -115,7 +115,7 @@ namespace EnvironmentManager4
             // cbAlwaysOnTop
             // 
             this.cbAlwaysOnTop.AutoSize = true;
-            this.cbAlwaysOnTop.Location = new System.Drawing.Point(11, 565);
+            this.cbAlwaysOnTop.Location = new System.Drawing.Point(419, 4);
             this.cbAlwaysOnTop.Name = "cbAlwaysOnTop";
             this.cbAlwaysOnTop.Size = new System.Drawing.Size(98, 17);
             this.cbAlwaysOnTop.TabIndex = 16;
@@ -197,13 +197,6 @@ namespace EnvironmentManager4
             // cbProductList
             // 
             this.cbProductList.FormattingEnabled = true;
-            this.cbProductList.Items.AddRange(new object[] {
-            "SalesPad GP",
-            "DataCollection",
-            "SalesPad Mobile",
-            "ShipCenter",
-            "Customer Portal Web",
-            "Customer Portal API"});
             this.cbProductList.Location = new System.Drawing.Point(6, 18);
             this.cbProductList.Name = "cbProductList";
             this.cbProductList.Size = new System.Drawing.Size(425, 21);
@@ -358,7 +351,7 @@ namespace EnvironmentManager4
             this.groupBox2.Size = new System.Drawing.Size(252, 222);
             this.groupBox2.TabIndex = 12;
             this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "SQL Server Management";
+            this.groupBox2.Text = "SQL Service Management";
             // 
             // lvInstalledSQLServers
             // 
@@ -424,9 +417,9 @@ namespace EnvironmentManager4
             this.labelSQLVersions.ForeColor = System.Drawing.SystemColors.ControlText;
             this.labelSQLVersions.Location = new System.Drawing.Point(6, 20);
             this.labelSQLVersions.Name = "labelSQLVersions";
-            this.labelSQLVersions.Size = new System.Drawing.Size(70, 13);
+            this.labelSQLVersions.Size = new System.Drawing.Size(75, 13);
             this.labelSQLVersions.TabIndex = 3;
-            this.labelSQLVersions.Text = "SQL Servers:";
+            this.labelSQLVersions.Text = "SQL Services:";
             this.labelSQLVersions.Click += new System.EventHandler(this.labelSQLVersions_Click);
             // 
             // btnInstallService

--- a/EnvironmentManager4/Form1.cs
+++ b/EnvironmentManager4/Form1.cs
@@ -292,7 +292,7 @@ namespace EnvironmentManager4
         {
             cbSPGPVersion.Text = "x86";
             SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
-            if (settingsModel.Other.Mode == "Standard")
+            if (settingsModel.Other.Mode == "Standard" || settingsModel.Other.Mode == "Kyle")
             {
                 cbProductList.Text = "Select a Product";
                 cbProductList.Enabled = true;
@@ -323,6 +323,10 @@ namespace EnvironmentManager4
             tbWiFiIPAddress.Text = Utilities.GetWiFiIPAddress();
             tbSPVPNIPAddress.Text = Utilities.GetSalesPadVPNIPAddress();
             LoadSQLServerListView();
+            foreach (string product in productList)
+            {
+                cbProductList.Items.Add(product);
+            }
             return;
         }
 
@@ -465,6 +469,12 @@ namespace EnvironmentManager4
 
         private void btnDBBackupFolder_Click(object sender, EventArgs e)
         {
+            //if (Control.ModifierKeys == Keys.Shift)
+            //{
+            //    TestTextPrompt test = new TestTextPrompt();
+            //    test.Show();
+            //    return;
+            //}
             string message = "Are you sure you want to open the database backup folder?";
             string caption = "CONFIRM";
             MessageBoxButtons buttons = MessageBoxButtons.YesNo;
@@ -659,34 +669,6 @@ namespace EnvironmentManager4
             }
 
             string productPath = Utilities.GetProductInstallPath(selectedProduct, selectedVersion);
-
-            //string productPath = "";
-            //switch (selectedProduct)
-            //{
-            //    case "SalesPad GP":
-            //        switch (selectedVersion)
-            //        {
-            //            case "x86":
-            //                productPath = settingsModel.BuildManagement.SalesPadx86Directory;
-            //                break;
-            //            case "x64":
-            //                productPath = settingsModel.BuildManagement.SalesPadx64Directory;
-            //                break;
-            //        }
-            //        break;
-            //    case "DataCollection":
-            //        productPath = settingsModel.BuildManagement.DataCollectionDirectory;
-            //        break;
-            //    case "Inventory Manager":
-            //        productPath = settingsModel.BuildManagement.DataCollectionDirectory;
-            //        break;
-            //    case "SalesPad Mobile":
-            //        productPath = settingsModel.BuildManagement.SalesPadMobileDirectory;
-            //        break;
-            //    case "ShipCenter":
-            //        productPath = settingsModel.BuildManagement.ShipCenterDirectory;
-            //        break;
-            //}
 
             if (!Directory.Exists(productPath))
             {

--- a/EnvironmentManager4/Form1.cs
+++ b/EnvironmentManager4/Form1.cs
@@ -52,6 +52,14 @@ namespace EnvironmentManager4
             {
                 form.EnableButton(enable);
             }
+            if (enable)
+            {
+                form.Cursor = Cursors.Default;
+            }
+            if (!enable)
+            {
+                form.Cursor = Cursors.WaitCursor;
+            }
         }
 
         private void EnableButton(bool enable)
@@ -90,12 +98,15 @@ namespace EnvironmentManager4
             btnInstallProduct.Enabled = enable;
         }
 
-        public void Reload()
+        public void Reload(bool settingsChange = false)
         {
             cbDatabaseList.Text = "Select a Database Backup";
             LoadDatabaseList();
             LoadDatabaseDescription(cbDatabaseList.Text);
-            DetermineMode();
+            if (settingsChange)
+            {
+                DetermineMode();
+            }
         }
 
         private void EnableSQLControls(bool enable)
@@ -307,7 +318,7 @@ namespace EnvironmentManager4
                 generateConfigurationsFileToolStripMenuItem.Visible = false;
                 generateConfigurationsFileWithNullsToolStripMenuItem.Visible = false;
             }
-            Reload();
+            Reload(true);
             LoadGPInstalls();
             tbWiFiIPAddress.Text = Utilities.GetWiFiIPAddress();
             tbSPVPNIPAddress.Text = Utilities.GetSalesPadVPNIPAddress();
@@ -325,7 +336,7 @@ namespace EnvironmentManager4
 
         private void SettingsClose(object sender, FormClosingEventArgs e)
         {
-            Reload();
+            Reload(true);
         }
 
         private void labelGPInstallationList_Click(object sender, EventArgs e)
@@ -698,6 +709,14 @@ namespace EnvironmentManager4
 
         private void btnBuildFolder_Click(object sender, EventArgs e)
         {
+            if (Control.ModifierKeys == Keys.Shift)
+            {
+                foreach (Control c in this.Controls)
+                {
+                    MessageBox.Show(c.Name);
+                }
+                return;
+            }
             string product = cbProductList.Text;
             string version = cbSPGPVersion.Text;
             string buildPath = "";
@@ -811,7 +830,8 @@ namespace EnvironmentManager4
         {
             if (!String.IsNullOrWhiteSpace(ListAndButtonForm.output))
             {
-                DatabaseManagement.ResetDatabaseVersion(ListAndButtonForm.output);
+                SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
+                DatabaseManagement.ResetDatabaseVersion(settingsModel.DbManagement.SQLServerUserName, Utilities.ToInsecureString(Utilities.DecryptString(settingsModel.DbManagement.SQLServerPassword)), ListAndButtonForm.output);
             }
             return;
         }

--- a/EnvironmentManager4/Install.cs
+++ b/EnvironmentManager4/Install.cs
@@ -136,7 +136,7 @@ namespace EnvironmentManager4
             string pathFromInstaller = installerPath.Remove(0, charCount);
             //check if smartbear mode
             SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
-            if (settingsModel.Other.Mode == "SmartBear")
+            if (settingsModel.Other.Mode == "SmartBear" || settingsModel.Other.Mode == "Kyle")
             {
                 return String.Format(@"{0} {1}", defaultPath, pathFromInstaller.Replace(@"\", " "));
             }
@@ -295,12 +295,12 @@ namespace EnvironmentManager4
 
             if (openInstallFolder)
             {
-                Process.Start(installPath);
+                build.LaunchInstalledFolder();
             }
 
             if (launchAfterInstall)
             {
-                Process.Start(String.Format(@"{0}\{1}", installPath, Utilities.RetrieveExe(product)));
+                build.LaunchBuild();
             }
             Form1.EnableInstallButton(true);
         }

--- a/EnvironmentManager4/Install.cs
+++ b/EnvironmentManager4/Install.cs
@@ -190,6 +190,9 @@ namespace EnvironmentManager4
 
         public void InstallBuild(string installPath, List<string> extendedModules, List<string> customModules, bool launchAfterInstall, bool openInstallFolder, bool runDatabaseUpdate, bool resetDatabaseVersion)
         {
+            //start the busy cursor
+            this.Cursor = Cursors.WaitCursor;
+
             //Disable Install button on form1.
             Form1.EnableInstallButton(false);
 
@@ -269,16 +272,17 @@ namespace EnvironmentManager4
             //  DLL INSTALL END
             //==========================================================================================================================================================================================
 
+            SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(File.ReadAllText(Utilities.GetSettingsFile()));
             if (resetDatabaseVersion)
             {
-                DatabaseManagement.ResetDatabaseVersion();
+                DatabaseManagement.ResetDatabaseVersion(settingsModel.DbManagement.SQLServerUserName, Utilities.ToInsecureString(Utilities.DecryptString(settingsModel.DbManagement.SQLServerPassword)));
             }
 
             if (runDatabaseUpdate)
             {
                 if (!resetDatabaseVersion)
                 {
-                    DatabaseManagement.ResetDatabaseVersion();
+                    DatabaseManagement.ResetDatabaseVersion(settingsModel.DbManagement.SQLServerUserName, Utilities.ToInsecureString(Utilities.DecryptString(settingsModel.DbManagement.SQLServerPassword)));
                 }
                 Process dbUpdate = new Process();
                 dbUpdate.StartInfo.FileName = installPath + @"\SalesPad.exe";
@@ -287,6 +291,7 @@ namespace EnvironmentManager4
                 dbUpdate.Start();
                 dbUpdate.WaitForExit();
             }
+            this.Cursor = Cursors.Default;
 
             if (openInstallFolder)
             {

--- a/EnvironmentManager4/Settings.Designer.cs
+++ b/EnvironmentManager4/Settings.Designer.cs
@@ -55,13 +55,19 @@ namespace EnvironmentManager4
             this.btnSelectSPx86Directory = new System.Windows.Forms.Button();
             this.tbSalesPadx86Directory = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.cbLocked = new System.Windows.Forms.CheckBox();
+            this.btnToggleVisibility = new System.Windows.Forms.Button();
+            this.btnDeleteConnection = new System.Windows.Forms.Button();
             this.btnRemove = new System.Windows.Forms.Button();
-            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnReload = new System.Windows.Forms.Button();
+            this.btnConnect = new System.Windows.Forms.Button();
+            this.cbConnections = new System.Windows.Forms.ComboBox();
+            this.label13 = new System.Windows.Forms.Label();
+            this.label12 = new System.Windows.Forms.Label();
+            this.tbSQLServerPW = new System.Windows.Forms.TextBox();
+            this.tbSQLServerUN = new System.Windows.Forms.TextBox();
             this.lbDatabases = new System.Windows.Forms.ListBox();
             this.label5 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
-            this.tbSQLServer = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.btnSelectBackupDirectory = new System.Windows.Forms.Button();
             this.tbdatabaseBackupDirectory = new System.Windows.Forms.TextBox();
@@ -75,20 +81,20 @@ namespace EnvironmentManager4
             // 
             // btnExit
             // 
-            this.btnExit.Location = new System.Drawing.Point(460, 440);
+            this.btnExit.Location = new System.Drawing.Point(428, 529);
             this.btnExit.Name = "btnExit";
             this.btnExit.Size = new System.Drawing.Size(75, 23);
-            this.btnExit.TabIndex = 7;
+            this.btnExit.TabIndex = 27;
             this.btnExit.Text = "Exit";
             this.btnExit.UseVisualStyleBackColor = true;
             this.btnExit.Click += new System.EventHandler(this.btnExit_Click);
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(385, 440);
+            this.btnSave.Location = new System.Drawing.Point(353, 529);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(75, 23);
-            this.btnSave.TabIndex = 6;
+            this.btnSave.TabIndex = 26;
             this.btnSave.Text = "Save";
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
@@ -117,7 +123,7 @@ namespace EnvironmentManager4
             this.groupBox2.Controls.Add(this.btnSelectSPx86Directory);
             this.groupBox2.Controls.Add(this.tbSalesPadx86Directory);
             this.groupBox2.ForeColor = System.Drawing.Color.Blue;
-            this.groupBox2.Location = new System.Drawing.Point(2, 192);
+            this.groupBox2.Location = new System.Drawing.Point(2, 281);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(532, 188);
             this.groupBox2.TabIndex = 5;
@@ -139,7 +145,7 @@ namespace EnvironmentManager4
             this.btnSelectWebAPIDirectory.Location = new System.Drawing.Point(501, 158);
             this.btnSelectWebAPIDirectory.Name = "btnSelectWebAPIDirectory";
             this.btnSelectWebAPIDirectory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectWebAPIDirectory.TabIndex = 22;
+            this.btnSelectWebAPIDirectory.TabIndex = 24;
             this.btnSelectWebAPIDirectory.Text = "...";
             this.btnSelectWebAPIDirectory.UseVisualStyleBackColor = true;
             this.btnSelectWebAPIDirectory.Click += new System.EventHandler(this.btnSelectWebAPIDirectory_Click);
@@ -150,7 +156,7 @@ namespace EnvironmentManager4
             this.tbWebAPIDirectory.Location = new System.Drawing.Point(151, 159);
             this.tbWebAPIDirectory.Name = "tbWebAPIDirectory";
             this.tbWebAPIDirectory.Size = new System.Drawing.Size(348, 20);
-            this.tbWebAPIDirectory.TabIndex = 21;
+            this.tbWebAPIDirectory.TabIndex = 23;
             // 
             // label10
             // 
@@ -167,7 +173,7 @@ namespace EnvironmentManager4
             this.btnSelectGPWebDirectory.Location = new System.Drawing.Point(501, 135);
             this.btnSelectGPWebDirectory.Name = "btnSelectGPWebDirectory";
             this.btnSelectGPWebDirectory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectGPWebDirectory.TabIndex = 19;
+            this.btnSelectGPWebDirectory.TabIndex = 22;
             this.btnSelectGPWebDirectory.Text = "...";
             this.btnSelectGPWebDirectory.UseVisualStyleBackColor = true;
             this.btnSelectGPWebDirectory.Click += new System.EventHandler(this.btnSelectGPWebDirectory_Click);
@@ -178,7 +184,7 @@ namespace EnvironmentManager4
             this.tbGPWebDirectory.Location = new System.Drawing.Point(151, 136);
             this.tbGPWebDirectory.Name = "tbGPWebDirectory";
             this.tbGPWebDirectory.Size = new System.Drawing.Size(348, 20);
-            this.tbGPWebDirectory.TabIndex = 18;
+            this.tbGPWebDirectory.TabIndex = 21;
             // 
             // label11
             // 
@@ -195,7 +201,7 @@ namespace EnvironmentManager4
             this.btnSelectShipCenterDirectory.Location = new System.Drawing.Point(501, 112);
             this.btnSelectShipCenterDirectory.Name = "btnSelectShipCenterDirectory";
             this.btnSelectShipCenterDirectory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectShipCenterDirectory.TabIndex = 16;
+            this.btnSelectShipCenterDirectory.TabIndex = 20;
             this.btnSelectShipCenterDirectory.Text = "...";
             this.btnSelectShipCenterDirectory.UseVisualStyleBackColor = true;
             this.btnSelectShipCenterDirectory.Click += new System.EventHandler(this.btnSelectShipCenterDirectory_Click);
@@ -206,7 +212,7 @@ namespace EnvironmentManager4
             this.tbShipCenterDirectory.Location = new System.Drawing.Point(151, 113);
             this.tbShipCenterDirectory.Name = "tbShipCenterDirectory";
             this.tbShipCenterDirectory.Size = new System.Drawing.Size(348, 20);
-            this.tbShipCenterDirectory.TabIndex = 15;
+            this.tbShipCenterDirectory.TabIndex = 19;
             // 
             // label6
             // 
@@ -223,7 +229,7 @@ namespace EnvironmentManager4
             this.btnSelectSalesPadMobileDirectory.Location = new System.Drawing.Point(501, 89);
             this.btnSelectSalesPadMobileDirectory.Name = "btnSelectSalesPadMobileDirectory";
             this.btnSelectSalesPadMobileDirectory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectSalesPadMobileDirectory.TabIndex = 13;
+            this.btnSelectSalesPadMobileDirectory.TabIndex = 18;
             this.btnSelectSalesPadMobileDirectory.Text = "...";
             this.btnSelectSalesPadMobileDirectory.UseVisualStyleBackColor = true;
             this.btnSelectSalesPadMobileDirectory.Click += new System.EventHandler(this.btnSelectSalesPadMobileDirectory_Click);
@@ -234,7 +240,7 @@ namespace EnvironmentManager4
             this.tbSalesPadMobileDirectory.Location = new System.Drawing.Point(151, 90);
             this.tbSalesPadMobileDirectory.Name = "tbSalesPadMobileDirectory";
             this.tbSalesPadMobileDirectory.Size = new System.Drawing.Size(348, 20);
-            this.tbSalesPadMobileDirectory.TabIndex = 12;
+            this.tbSalesPadMobileDirectory.TabIndex = 17;
             // 
             // label7
             // 
@@ -251,7 +257,7 @@ namespace EnvironmentManager4
             this.btnSelectDatacollectionDirectory.Location = new System.Drawing.Point(501, 66);
             this.btnSelectDatacollectionDirectory.Name = "btnSelectDatacollectionDirectory";
             this.btnSelectDatacollectionDirectory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectDatacollectionDirectory.TabIndex = 10;
+            this.btnSelectDatacollectionDirectory.TabIndex = 16;
             this.btnSelectDatacollectionDirectory.Text = "...";
             this.btnSelectDatacollectionDirectory.UseVisualStyleBackColor = true;
             this.btnSelectDatacollectionDirectory.Click += new System.EventHandler(this.btnSelectDatacollectionDirectory_Click);
@@ -262,7 +268,7 @@ namespace EnvironmentManager4
             this.tbDataCollectionDirectory.Location = new System.Drawing.Point(151, 67);
             this.tbDataCollectionDirectory.Name = "tbDataCollectionDirectory";
             this.tbDataCollectionDirectory.Size = new System.Drawing.Size(348, 20);
-            this.tbDataCollectionDirectory.TabIndex = 9;
+            this.tbDataCollectionDirectory.TabIndex = 15;
             // 
             // label3
             // 
@@ -279,7 +285,7 @@ namespace EnvironmentManager4
             this.btnSelectx64SPDirectory.Location = new System.Drawing.Point(501, 43);
             this.btnSelectx64SPDirectory.Name = "btnSelectx64SPDirectory";
             this.btnSelectx64SPDirectory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectx64SPDirectory.TabIndex = 7;
+            this.btnSelectx64SPDirectory.TabIndex = 14;
             this.btnSelectx64SPDirectory.Text = "...";
             this.btnSelectx64SPDirectory.UseVisualStyleBackColor = true;
             this.btnSelectx64SPDirectory.Click += new System.EventHandler(this.btnSelectx64SPDirectory_Click);
@@ -290,7 +296,7 @@ namespace EnvironmentManager4
             this.tbSalesPadx64Directory.Location = new System.Drawing.Point(151, 44);
             this.tbSalesPadx64Directory.Name = "tbSalesPadx64Directory";
             this.tbSalesPadx64Directory.Size = new System.Drawing.Size(348, 20);
-            this.tbSalesPadx64Directory.TabIndex = 6;
+            this.tbSalesPadx64Directory.TabIndex = 13;
             // 
             // label2
             // 
@@ -307,7 +313,7 @@ namespace EnvironmentManager4
             this.btnSelectSPx86Directory.Location = new System.Drawing.Point(501, 20);
             this.btnSelectSPx86Directory.Name = "btnSelectSPx86Directory";
             this.btnSelectSPx86Directory.Size = new System.Drawing.Size(24, 22);
-            this.btnSelectSPx86Directory.TabIndex = 4;
+            this.btnSelectSPx86Directory.TabIndex = 12;
             this.btnSelectSPx86Directory.Text = "...";
             this.btnSelectSPx86Directory.UseVisualStyleBackColor = true;
             this.btnSelectSPx86Directory.Click += new System.EventHandler(this.btnSelectSPx86Directory_Click);
@@ -318,73 +324,150 @@ namespace EnvironmentManager4
             this.tbSalesPadx86Directory.Location = new System.Drawing.Point(151, 21);
             this.tbSalesPadx86Directory.Name = "tbSalesPadx86Directory";
             this.tbSalesPadx86Directory.Size = new System.Drawing.Size(348, 20);
-            this.tbSalesPadx86Directory.TabIndex = 3;
+            this.tbSalesPadx86Directory.TabIndex = 11;
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.cbLocked);
+            this.groupBox1.Controls.Add(this.btnToggleVisibility);
+            this.groupBox1.Controls.Add(this.btnDeleteConnection);
             this.groupBox1.Controls.Add(this.btnRemove);
-            this.groupBox1.Controls.Add(this.btnAdd);
+            this.groupBox1.Controls.Add(this.btnReload);
+            this.groupBox1.Controls.Add(this.btnConnect);
+            this.groupBox1.Controls.Add(this.cbConnections);
+            this.groupBox1.Controls.Add(this.label13);
+            this.groupBox1.Controls.Add(this.label12);
+            this.groupBox1.Controls.Add(this.tbSQLServerPW);
+            this.groupBox1.Controls.Add(this.tbSQLServerUN);
             this.groupBox1.Controls.Add(this.lbDatabases);
             this.groupBox1.Controls.Add(this.label5);
             this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Controls.Add(this.tbSQLServer);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Controls.Add(this.btnSelectBackupDirectory);
             this.groupBox1.Controls.Add(this.tbdatabaseBackupDirectory);
             this.groupBox1.ForeColor = System.Drawing.Color.Blue;
             this.groupBox1.Location = new System.Drawing.Point(2, 3);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(532, 184);
+            this.groupBox1.Size = new System.Drawing.Size(532, 275);
             this.groupBox1.TabIndex = 4;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Database Management";
             // 
-            // cbLocked
+            // btnToggleVisibility
             // 
-            this.cbLocked.Appearance = System.Windows.Forms.Appearance.Button;
-            this.cbLocked.AutoSize = true;
-            this.cbLocked.Image = ((System.Drawing.Image)(resources.GetObject("cbLocked.Image")));
-            this.cbLocked.Location = new System.Drawing.Point(501, 40);
-            this.cbLocked.Name = "cbLocked";
-            this.cbLocked.Size = new System.Drawing.Size(26, 26);
-            this.cbLocked.TabIndex = 10;
-            this.cbLocked.UseVisualStyleBackColor = true;
-            this.cbLocked.CheckedChanged += new System.EventHandler(this.cbLocked_CheckedChanged);
+            this.btnToggleVisibility.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnToggleVisibility.Location = new System.Drawing.Point(501, 89);
+            this.btnToggleVisibility.Name = "btnToggleVisibility";
+            this.btnToggleVisibility.Size = new System.Drawing.Size(24, 22);
+            this.btnToggleVisibility.TabIndex = 6;
+            this.btnToggleVisibility.Text = "---";
+            this.btnToggleVisibility.UseVisualStyleBackColor = true;
+            this.btnToggleVisibility.Click += new System.EventHandler(this.btnToggleVisibility_Click);
+            // 
+            // btnDeleteConnection
+            // 
+            this.btnDeleteConnection.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnDeleteConnection.Image = ((System.Drawing.Image)(resources.GetObject("btnDeleteConnection.Image")));
+            this.btnDeleteConnection.Location = new System.Drawing.Point(501, 42);
+            this.btnDeleteConnection.Name = "btnDeleteConnection";
+            this.btnDeleteConnection.Size = new System.Drawing.Size(24, 23);
+            this.btnDeleteConnection.TabIndex = 3;
+            this.btnDeleteConnection.UseVisualStyleBackColor = true;
+            this.btnDeleteConnection.Click += new System.EventHandler(this.btnDeleteConnection_Click);
             // 
             // btnRemove
             // 
-            this.btnRemove.Image = ((System.Drawing.Image)(resources.GetObject("btnRemove.Image")));
-            this.btnRemove.Location = new System.Drawing.Point(501, 127);
+            this.btnRemove.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnRemove.Location = new System.Drawing.Point(425, 247);
             this.btnRemove.Name = "btnRemove";
-            this.btnRemove.Size = new System.Drawing.Size(24, 22);
-            this.btnRemove.TabIndex = 9;
+            this.btnRemove.Size = new System.Drawing.Size(75, 23);
+            this.btnRemove.TabIndex = 10;
+            this.btnRemove.Text = "Remove";
             this.btnRemove.UseVisualStyleBackColor = true;
-            this.btnRemove.Click += new System.EventHandler(this.btnRemove_Click);
+            this.btnRemove.Click += new System.EventHandler(this.btnRemove_Click_1);
             // 
-            // btnAdd
+            // btnReload
             // 
-            this.btnAdd.Image = ((System.Drawing.Image)(resources.GetObject("btnAdd.Image")));
-            this.btnAdd.Location = new System.Drawing.Point(501, 105);
-            this.btnAdd.Name = "btnAdd";
-            this.btnAdd.Size = new System.Drawing.Size(24, 22);
-            this.btnAdd.TabIndex = 8;
-            this.btnAdd.UseVisualStyleBackColor = true;
-            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            this.btnReload.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnReload.Location = new System.Drawing.Point(350, 247);
+            this.btnReload.Name = "btnReload";
+            this.btnReload.Size = new System.Drawing.Size(75, 23);
+            this.btnReload.TabIndex = 9;
+            this.btnReload.Text = "Reload";
+            this.btnReload.UseVisualStyleBackColor = true;
+            this.btnReload.Click += new System.EventHandler(this.btnReload_Click);
+            // 
+            // btnConnect
+            // 
+            this.btnConnect.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.btnConnect.Location = new System.Drawing.Point(425, 111);
+            this.btnConnect.Name = "btnConnect";
+            this.btnConnect.Size = new System.Drawing.Size(75, 23);
+            this.btnConnect.TabIndex = 7;
+            this.btnConnect.Text = "Connect";
+            this.btnConnect.UseVisualStyleBackColor = true;
+            this.btnConnect.Click += new System.EventHandler(this.btnConnect_Click);
+            // 
+            // cbConnections
+            // 
+            this.cbConnections.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
+            this.cbConnections.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
+            this.cbConnections.FormattingEnabled = true;
+            this.cbConnections.Location = new System.Drawing.Point(151, 43);
+            this.cbConnections.Name = "cbConnections";
+            this.cbConnections.Size = new System.Drawing.Size(348, 21);
+            this.cbConnections.TabIndex = 2;
+            this.cbConnections.SelectedIndexChanged += new System.EventHandler(this.cbConnections_SelectedIndexChanged);
+            // 
+            // label13
+            // 
+            this.label13.AutoSize = true;
+            this.label13.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.label13.Location = new System.Drawing.Point(7, 94);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(74, 13);
+            this.label13.TabIndex = 14;
+            this.label13.Text = "SQLPassword";
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.label12.Location = new System.Drawing.Point(7, 70);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(82, 13);
+            this.label12.TabIndex = 13;
+            this.label12.Text = "SQL Username:";
+            // 
+            // tbSQLServerPW
+            // 
+            this.tbSQLServerPW.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.tbSQLServerPW.Location = new System.Drawing.Point(151, 90);
+            this.tbSQLServerPW.Name = "tbSQLServerPW";
+            this.tbSQLServerPW.Size = new System.Drawing.Size(348, 20);
+            this.tbSQLServerPW.TabIndex = 5;
+            this.tbSQLServerPW.UseSystemPasswordChar = true;
+            // 
+            // tbSQLServerUN
+            // 
+            this.tbSQLServerUN.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.tbSQLServerUN.Location = new System.Drawing.Point(151, 67);
+            this.tbSQLServerUN.Name = "tbSQLServerUN";
+            this.tbSQLServerUN.Size = new System.Drawing.Size(348, 20);
+            this.tbSQLServerUN.TabIndex = 4;
             // 
             // lbDatabases
             // 
             this.lbDatabases.FormattingEnabled = true;
-            this.lbDatabases.Location = new System.Drawing.Point(151, 66);
+            this.lbDatabases.Location = new System.Drawing.Point(151, 138);
             this.lbDatabases.Name = "lbDatabases";
             this.lbDatabases.Size = new System.Drawing.Size(348, 108);
-            this.lbDatabases.TabIndex = 7;
+            this.lbDatabases.TabIndex = 8;
             // 
             // label5
             // 
             this.label5.AutoSize = true;
             this.label5.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.label5.Location = new System.Drawing.Point(7, 69);
+            this.label5.Location = new System.Drawing.Point(7, 141);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(61, 13);
             this.label5.TabIndex = 6;
@@ -396,17 +479,9 @@ namespace EnvironmentManager4
             this.label4.ForeColor = System.Drawing.SystemColors.ControlText;
             this.label4.Location = new System.Drawing.Point(7, 46);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(65, 13);
+            this.label4.Size = new System.Drawing.Size(64, 13);
             this.label4.TabIndex = 4;
-            this.label4.Text = "SQL Server:";
-            // 
-            // tbSQLServer
-            // 
-            this.tbSQLServer.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.tbSQLServer.Location = new System.Drawing.Point(151, 43);
-            this.tbSQLServer.Name = "tbSQLServer";
-            this.tbSQLServer.Size = new System.Drawing.Size(348, 20);
-            this.tbSQLServer.TabIndex = 3;
+            this.label4.Text = "Connection:";
             // 
             // label1
             // 
@@ -441,7 +516,7 @@ namespace EnvironmentManager4
             this.groupBox3.Controls.Add(this.cbMode);
             this.groupBox3.Controls.Add(this.label8);
             this.groupBox3.ForeColor = System.Drawing.Color.Blue;
-            this.groupBox3.Location = new System.Drawing.Point(2, 387);
+            this.groupBox3.Location = new System.Drawing.Point(2, 476);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(533, 51);
             this.groupBox3.TabIndex = 8;
@@ -456,8 +531,8 @@ namespace EnvironmentManager4
             "SmartBear"});
             this.cbMode.Location = new System.Drawing.Point(151, 17);
             this.cbMode.Name = "cbMode";
-            this.cbMode.Size = new System.Drawing.Size(373, 21);
-            this.cbMode.TabIndex = 1;
+            this.cbMode.Size = new System.Drawing.Size(349, 21);
+            this.cbMode.TabIndex = 25;
             this.cbMode.SelectedIndexChanged += new System.EventHandler(this.cbMode_SelectedIndexChanged);
             // 
             // label8
@@ -474,7 +549,8 @@ namespace EnvironmentManager4
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(537, 465);
+            this.CancelButton = this.btnExit;
+            this.ClientSize = new System.Drawing.Size(537, 554);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.btnExit);
             this.Controls.Add(this.btnSave);
@@ -486,6 +562,7 @@ namespace EnvironmentManager4
             this.Name = "Settings";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Settings";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormIsClosing);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
@@ -509,13 +586,9 @@ namespace EnvironmentManager4
         private System.Windows.Forms.Button btnSelectSPx86Directory;
         private System.Windows.Forms.TextBox tbSalesPadx86Directory;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.CheckBox cbLocked;
-        private System.Windows.Forms.Button btnRemove;
-        private System.Windows.Forms.Button btnAdd;
         private System.Windows.Forms.ListBox lbDatabases;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label4;
-        private System.Windows.Forms.TextBox tbSQLServer;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnSelectBackupDirectory;
         private System.Windows.Forms.TextBox tbdatabaseBackupDirectory;
@@ -537,5 +610,15 @@ namespace EnvironmentManager4
         private System.Windows.Forms.GroupBox groupBox3;
         private System.Windows.Forms.ComboBox cbMode;
         private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.TextBox tbSQLServerPW;
+        private System.Windows.Forms.TextBox tbSQLServerUN;
+        private System.Windows.Forms.ComboBox cbConnections;
+        private System.Windows.Forms.Button btnRemove;
+        private System.Windows.Forms.Button btnReload;
+        private System.Windows.Forms.Button btnConnect;
+        private System.Windows.Forms.Button btnDeleteConnection;
+        private System.Windows.Forms.Button btnToggleVisibility;
     }
 }

--- a/EnvironmentManager4/Settings.Designer.cs
+++ b/EnvironmentManager4/Settings.Designer.cs
@@ -81,6 +81,7 @@ namespace EnvironmentManager4
             // 
             // btnExit
             // 
+            this.btnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.btnExit.Location = new System.Drawing.Point(428, 529);
             this.btnExit.Name = "btnExit";
             this.btnExit.Size = new System.Drawing.Size(75, 23);
@@ -528,7 +529,8 @@ namespace EnvironmentManager4
             this.cbMode.FormattingEnabled = true;
             this.cbMode.Items.AddRange(new object[] {
             "Standard",
-            "SmartBear"});
+            "SmartBear",
+            "Kyle"});
             this.cbMode.Location = new System.Drawing.Point(151, 17);
             this.cbMode.Name = "cbMode";
             this.cbMode.Size = new System.Drawing.Size(349, 21);
@@ -562,7 +564,7 @@ namespace EnvironmentManager4
             this.Name = "Settings";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Settings";
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormIsClosing);
+            //this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormIsClosing);
             this.Load += new System.EventHandler(this.Settings_Load);
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();

--- a/EnvironmentManager4/Settings.resx
+++ b/EnvironmentManager4/Settings.resx
@@ -118,17 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="cbLocked.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAP1JREFUOE/tkr0OAUEURvcRPIPn0ItOqyGIzgOoRLyMVqelERrjJxoiEipENiGE
-        teaabzObDG7sklA5yZedzNw5cyez1k8hooqU0lZfDz2u6OX3UJuF3AlyJyVyxwVyBlk6iiI5mw7EQpeF
-        A114MiUy4wxzZDeTdF610XD4TnE1v7PrrEqQIxgfuinattLe9XX5a9TJERzvdwURukEwPokMrRtxzJHe
-        8hpVdycE5vxllH9PCFD8KAT+fGihV6UxhSam0EdvfwaLy3qCzaIWZRMolMc5n32PTaDQnZbZXPoxNn/h
-        PV8Rsi+MMC+MBAq5fxDh/kEkUPgJevs3sKwb4YLrGRoBQAgAAAAASUVORK5CYII=
-</value>
-  </data>
-  <data name="btnRemove.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+  <data name="btnDeleteConnection.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABUAAAAVCAYAAACpF6WWAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
         wwAADsMBx2+oZAAAAXpJREFUOE+1lb1OwzAURr3AUrXAhERKgfJCPAIjYmLiNZDagQdAhQHRDDwDEhML
@@ -138,22 +128,6 @@
         nBmAgAVInvFwjXhroPRfOAG54M+nV/NMARGcGnrfG0YnIQCzx2cD5JkCIg+a2imSIws49NiVB031p+vh
         cWe14XEox9N49WNFcT2Ogevqp/r0Zu8gWhQBM+7mvT4l+BLC3V71BsmikGfcy7lfFPEv3z7BLdMG7AB/
         vv6w4k/uUwmOgDcCZyf0n4h3W+U5b343bFe0+Ucp9QV6YQ0iKNqOGQAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <data name="btnAdd.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAABUAAAAVCAYAAACpF6WWAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAlhJREFUOE+dlc1qE1EUx6dpKwg2TRObUlsiSUzMfKSTWi20pBV8gjxCqj5Bd27i
-        ThfCPa5dNBLE5WQTW41NFPdCUYvuAuIT+ALH+zlz5yMWeuDPJHfu+fG/5957xpgWFbjXvkXu9suwhUW4
-        gzehgQVwcR3qeIPY/RWw2nLqxWHCTqtGtidV2EazV0TLy6EzuIa2VM1bwlJvDVfBxjwxJ3kwWzI1OSyy
-        CxbsoNWtojuaRfezQTWTIAOd4TwWuuu4DDXMkQpIRDgcCrRhF+veMk/iyZ+EGuNALpMcZ/Mq3iLmoIpL
-        UbADzVYdmrjh5QWQJSjQKBXXmEmBZyg4jVmo4CKUg1LUSXOy0TXDQAU4TZAPD8Br3VXMkPKEA13Ya1PR
-        Gs7xlzHgx9m4dLgE27TGGShTt6W20SD7fbdHN0a69JesgMME0fHHXx9IaCpw28tjmhT7xibcR9dbES4Z
-        NAr8MIebTO/Fk/3v/HiILN78fhlyW/YWMA0lFNBBhkOTXPrAE/HsfBfA8z9nuPUqG4LeHlyNQLWld84P
-        8NffM9wb5wLg8Tx2vj3yge7zLLonFPhfqOb0yZcDnszA+6PrwqEOfEaBx3Qlp1RToaqmEmq+TuHh2wD8
-        4uch/+0D31GYOgUa1K9pfPfFRB3MIgbUoCwvtPuufk45VLhlCQrs15AtOQJULkPnlEX0Rvlg6bj4lLph
-        m8JqyGARIHd5pN0oFuG7LyZysCxFojRg4t1nEe5SMsGHh6XeCeCULqUi3E9lL1AAXXTcGV7BwtEF/VRF
-        cudfuHzn1+Py3yjD+Aei0t/NINbingAAAABJRU5ErkJggg==
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/EnvironmentManager4/SettingsModel.cs
+++ b/EnvironmentManager4/SettingsModel.cs
@@ -16,9 +16,12 @@ namespace EnvironmentManager4
     public class DbManagement
     {
         public string DatabaseBackupDirectory { get; set; }
-        public string SQLServer { get; set; }
+        public string Connection { get; set; }
+        public List<ConnectionList> ConnectionsList { get; set; }
+        public string SQLServerUserName { get; set; }
+        public string SQLServerPassword { get; set; }
         public List<string> Databases { get; set; }
-        public bool LockedIn { get; set; }
+        public bool Connected { get; set; }
     }
 
     public class BuildManagement
@@ -35,5 +38,12 @@ namespace EnvironmentManager4
     public class Other
     {
         public string Mode { get; set; }
+    }
+
+    public class ConnectionList
+    {
+        public string ConnectionName { get; set; }
+        public string ConnectionUN { get; set; }
+        public string ConnectionPW { get; set; }
     }
 }

--- a/EnvironmentManager4/TextPrompt.Designer.cs
+++ b/EnvironmentManager4/TextPrompt.Designer.cs
@@ -34,11 +34,12 @@ namespace EnvironmentManager4
             this.btnOK = new System.Windows.Forms.Button();
             this.tbText = new System.Windows.Forms.TextBox();
             this.labelPrompt = new System.Windows.Forms.Label();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.SuspendLayout();
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(274, 54);
+            this.btnCancel.Location = new System.Drawing.Point(203, 77);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 7;
@@ -48,7 +49,7 @@ namespace EnvironmentManager4
             // 
             // btnOK
             // 
-            this.btnOK.Location = new System.Drawing.Point(193, 54);
+            this.btnOK.Location = new System.Drawing.Point(126, 77);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
             this.btnOK.TabIndex = 6;
@@ -58,29 +59,39 @@ namespace EnvironmentManager4
             // 
             // tbText
             // 
-            this.tbText.Location = new System.Drawing.Point(14, 28);
+            this.tbText.Location = new System.Drawing.Point(21, 33);
             this.tbText.Name = "tbText";
-            this.tbText.Size = new System.Drawing.Size(334, 20);
+            this.tbText.Size = new System.Drawing.Size(244, 20);
             this.tbText.TabIndex = 5;
             // 
             // labelPrompt
             // 
             this.labelPrompt.AutoSize = true;
-            this.labelPrompt.Location = new System.Drawing.Point(13, 12);
+            this.labelPrompt.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(250)))), ((int)(((byte)(250)))), ((int)(((byte)(250)))));
+            this.labelPrompt.Location = new System.Drawing.Point(21, 17);
             this.labelPrompt.Name = "labelPrompt";
             this.labelPrompt.Size = new System.Drawing.Size(35, 13);
             this.labelPrompt.TabIndex = 4;
             this.labelPrompt.Text = "label1";
             // 
+            // panel1
+            // 
+            this.panel1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(250)))), ((int)(((byte)(250)))), ((int)(((byte)(250)))));
+            this.panel1.Location = new System.Drawing.Point(1, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(285, 71);
+            this.panel1.TabIndex = 8;
+            // 
             // TextPrompt
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(362, 89);
+            this.ClientSize = new System.Drawing.Size(282, 104);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
             this.Controls.Add(this.tbText);
             this.Controls.Add(this.labelPrompt);
+            this.Controls.Add(this.panel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -99,5 +110,6 @@ namespace EnvironmentManager4
         private System.Windows.Forms.Button btnOK;
         private System.Windows.Forms.TextBox tbText;
         private System.Windows.Forms.Label labelPrompt;
+        private System.Windows.Forms.Panel panel1;
     }
 }

--- a/EnvironmentManager4/Utilities.cs
+++ b/EnvironmentManager4/Utilities.cs
@@ -32,8 +32,8 @@ namespace EnvironmentManager4
 
         public static string GetSettingsFile()
         {
-            return Environment.CurrentDirectory + @"\Files\Settings.json";
-            //return @"C:\Program Files (x86)\EnvMgr\Files\Settings.json";
+            //return Environment.CurrentDirectory + @"\Files\Settings.json";
+            return @"C:\Program Files (x86)\EnvMgr\Files\Settings.json";
             //return @"C:\Users\steve.rodriguez\Desktop\test\EnvMgr Settings\Settings.json";
         }
 
@@ -174,6 +174,7 @@ namespace EnvironmentManager4
                                     productPath = settingsModel.BuildManagement.SalesPadx86Directory;
                                     break;
                                 case "SmartBear":
+                                case "Kyle":
                                     productPath = TrimEndOfPath(settingsModel.BuildManagement.SalesPadx86Directory);
                                     break;
                             }
@@ -566,6 +567,15 @@ namespace EnvironmentManager4
                 System.Runtime.InteropServices.Marshal.ZeroFreeBSTR(ptr);
             }
             return returnValue;
+        }
+
+        public static void ResizeListviewColumnWidth(ListView lv, int rowCount, int indx, int minW, int maxW)
+        {
+            int count = lv.Items.Count;
+            if (count > rowCount)
+                lv.Columns[indx].Width = minW;
+            else
+                lv.Columns[indx].Width = maxW;
         }
     }
 }

--- a/EnvironmentManager4/Variance.cs
+++ b/EnvironmentManager4/Variance.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EnvironmentManager4
+{
+    public class Variance
+    {
+        public string PropertyName { get; set; }
+        public object valA { get; set; }
+        public object valB { get; set; }
+    }
+
+    public static class Comparision
+    {
+        public static List<Variance> Compare<T>(this T val1, T val2)
+        {
+            var variances = new List<Variance>();
+            var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            foreach (var property in properties)
+            {
+                if (property.Name != "SQLServerPassword" && property.Name != "Databases")
+                {
+                    var v = new Variance
+                    {
+                        PropertyName = property.Name,
+                        valA = property.GetValue(val1),
+                        valB = property.GetValue(val2)
+                    };
+                    if (v.valA == null && v.valB == null)
+                    {
+                        continue;
+                    }
+                    if (
+                        (v.valA == null && v.valB != null)
+                        ||
+                        (v.valA != null && v.valB == null)
+                    )
+                    {
+                        variances.Add(v);
+                        continue;
+                    }
+                    if (!v.valA.Equals(v.valB))
+                    {
+                        variances.Add(v);
+                    }
+                }
+            }
+            return variances;
+        }
+    }
+}


### PR DESCRIPTION
FIXED:
- ConnectionList items would get duplicated - this was due to adding connectionList items from the Settings file to the connectionsInMemory variable regardless if they existed there already or not. I now check to see if the connection already exists in the variable before adding it
- Selecting a connection from the list would load the masked password, not the actual password. This potentially would break connection. The fix was to decrypt the password.
- Selecting no to my save changes on close prompt would result in the prompt being displayed a second time. It turns out I was subscribing to the FormClosingEvent twice due to manually coding the action, as well as it being auto-generated due to using the form designer. Commented out the call on the designer file.
- Connection got wonky if the connection failed, the fields would still be read-only by the Connect(true) method call. I just moved the method call to inside the try block of the SQL connection. 